### PR TITLE
Update people page and data

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -5,9 +5,10 @@ menu:
 - {name: 'contact', url: '/contact'}
 
 people:
-- {name: 'Darya Frank', title: 'Royal Society URF', department: 'Andrew Mayes Centre for Cognitive Neuroscience', institution: 'The University of Manchester', email: 'darya.frank@manchester.ac.uk', image: 'assets/img/primary-investigator.jpg', url: 'primary-investigator'}
-- {name: 'Lab Technician', title: 'Researcher', department: 'Physics & Astronomy', institution: 'Some University', institution_address: '1 Main Street, Canada', phone: '(000) 000-0000', email: 'hello@university.edu', office: 'Science Building 505', image: 'assets/img/lab-technician.jpg', url: 'lab-technician'}
-- {name: 'Graduate Student', title: 'Researcher', department: 'Physics & Astronomy', institution: 'Some University', institution_address: '1 Main Street, Canada', phone: '(000) 000-0000', email: 'hello@university.edu', office: 'Science Building 505', image: 'assets/img/graduate-student.jpg', url: 'graduate-student'}
+- {name: 'Darya Frank', title: 'PI', email: 'darya.frank@manchester.ac.uk', image: 'assets/img/primary-investigator.jpg', url: 'darya-frank'}
+- {name: 'Marta Garcia Huescar', title: 'PhD Student', institution: 'Universidad Politecnica de Madrid', image: 'assets/img/graduate-student.jpg', url: 'marta-garcia-huescar'}
+- {name: 'Aysha Janjua', title: "Master's Student", image: 'assets/img/graduate-student.jpg', url: 'aysha-janjua'}
+- {name: 'Zhiyun Qin', title: "Master's Student", image: 'assets/img/graduate-student.jpg', url: 'zhiyun-qin'}
 
 courses:
 - {name: 'Vector Calculus', url: 'vector-calculus'}

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -8,10 +8,10 @@ layout: default
 {% for person in site.data.settings.people %}
 <div class="row g-5 mb-5">
   <div class="col-md-6">
-    <h5>{{ person.name }}</h5>
-    <p>Email: {{ person.email }}</p>
-    <p>Phone: {{ person.phone }}</p>
-    <p><a href="{{ site.github.url }}/people/{{ person.url }}">More info</a></p>
+    <h5>{{ person.title }} - {{ person.name }}</h5>
+    {% if person.institution %}
+    <p>{{ person.institution }}</p>
+    {% endif %}
   </div>
   <div class="col-md-6">
     <img src="{{ site.github.url }}/{{ person.image }}" alt="Contact" width="100%">

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -8,10 +8,10 @@ layout: default
 {% for person in site.data.settings.people %}
 <div class="row g-5 mb-5">
   <div class="col-md-6">
-    <h5>{{ person.name }}</h5>
-    <p>Email: {{ person.email }}</p>
-    <p>Phone: {{ person.phone }}</p>
-    <p><a href="{{ site.github.url }}/people/{{ person.url }}">More info</a></p>
+    <h5>{{ person.title }} - {{ person.name }}</h5>
+    {% if person.institution %}
+    <p>{{ person.institution }}</p>
+    {% endif %}
   </div>
   <div class="col-md-6">
     <img src="{{ site.github.url }}/{{ person.image }}" alt="Contact" width="100%">

--- a/people.md
+++ b/people.md
@@ -3,3 +3,9 @@ layout: people
 title: People
 ---
 
+## Lab Members
+
+- **PI**: Darya Frank
+- **PhD student**: Marta Garcia Huescar (Universidad Politecnica de Madrid)
+- **Master's students**: Aysha Janjua, Zhiyun Qin
+


### PR DESCRIPTION
## Summary
- list current lab members on the People page
- revise layout and include template to show roles and institutions
- update people data with new lab members

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e6b54df98832eaf9d58ced841ae6b