### PR TITLE
Update people page to team

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -1,5 +1,5 @@
 menu:
-- {name: 'people', url: '/people'}
+- {name: 'team', url: '/people'}
 - {name: 'publications', url: '/publications'}
 - {name: 'courses', url: '/courses'}
 - {name: 'contact', url: '/contact'}

--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -4,7 +4,7 @@ layout: default
 
 {{ content }}
 
-<h3 class="fw-bold border-bottom pb-3 mb-5">People</h3>
+<h3 class="fw-bold border-bottom pb-3 mb-5">Team</h3>
 {% for person in site.data.settings.people %}
 <div class="row g-5 mb-5">
   <div class="col-md-6">

--- a/index.md
+++ b/index.md
@@ -27,5 +27,5 @@ We use a multimodal approach to investigate memory, including:
 
 ### Join Our Team
 
-We are always looking for motivated researchers to join our group. If you are interested in [research areas], please see our [People](/people) page for information about current opportunities, or [contact us](/contact) directly.
+We are always looking for motivated researchers to join our group. If you are interested in [research areas], please see our [Team](/people) page for information about current opportunities, or [contact us](/contact) directly.
 

--- a/people.md
+++ b/people.md
@@ -1,11 +1,5 @@
 ---
-layout: people
-title: People
+layout: team
+title: Team
 ---
-
-## Lab Members
-
-- **PI**: Darya Frank
-- **PhD student**: Marta Garcia Huescar (Universidad Politecnica de Madrid)
-- **Master's students**: Aysha Janjua, Zhiyun Qin
 


### PR DESCRIPTION
## Summary
- rename the People layout to Team
- remove duplicate member list
- update navigation to show Team
- fix front page text to link to Team

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e7b3e7d2c832ead8a53eb0c432b37