### PR TITLE
Add bios to PhD students

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -5,8 +5,8 @@ menu:
 
 people:
 - {name: 'Darya Frank', title: 'PI', email: 'darya.frank@manchester.ac.uk', image: 'assets/img/primary-investigator.jpg'}
-- {name: 'Marta Garcia Huescar', title: 'PhD Student', email: 'marta.garcia@ctb.upm.es', institution: 'Universidad Politecnica de Madrid', image: 'assets/img/graduate-student.jpg'}
-- {name: 'Haoran Guan', title: 'PhD Student', email: 'haoran.guan@manchester.ac.uk', image: 'assets/img/graduate-student.jpg'}
+- {name: 'Marta Garcia Huescar', title: 'PhD Student', email: 'marta.garcia@ctb.upm.es', institution: 'Universidad Politecnica de Madrid', image: 'assets/img/graduate-student.jpg', text: 'Researches the neural basis of memory formation using advanced imaging and computational modeling.'}
+- {name: 'Haoran Guan', title: 'PhD Student', email: 'haoran.guan@manchester.ac.uk', image: 'assets/img/graduate-student.jpg', text: 'Focuses on modeling cognitive processes and their links to perceptual memory.'}
 - {name: 'Aysha Janjua', title: 'MRes Student'}
 - {name: 'Zhiyun Qin', title: 'MRes Student'}
 

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -15,8 +15,10 @@ layout: default
     {% if person.institution %}
     <p>{{ person.institution }}</p>
     {% endif %}
-    {% if person.title == 'Post doc' and person.text %}
-    <p>{{ person.text }}</p>
+    {% if person.title == 'Post doc' or person.title == 'PhD Student' %}
+      {% if person.text %}
+      <p>{{ person.text }}</p>
+      {% endif %}
     {% endif %}
   </div>
   {% unless person.title == 'MRes Student' %}

--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -15,8 +15,10 @@ layout: default
     {% if person.institution %}
     <p>{{ person.institution }}</p>
     {% endif %}
-    {% if person.title == 'Post doc' and person.text %}
-    <p>{{ person.text }}</p>
+    {% if person.title == 'Post doc' or person.title == 'PhD Student' %}
+      {% if person.text %}
+      <p>{{ person.text }}</p>
+      {% endif %}
     {% endif %}
   </div>
   {% unless person.title == 'MRes Student' %}


### PR DESCRIPTION
## Summary
- show `person.text` for PhD students
- add short bios for two PhD students

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e85f0d0e0832ebb73cc57d381785f