### PR TITLE
Show team member names before titles

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -4,7 +4,7 @@ menu:
 - {name: 'contact', url: '/contact'}
 
 people:
-- {name: 'Darya Frank', title: 'PI', email: 'darya.frank@manchester.ac.uk', image: 'assets/img/primary-investigator.jpg'}
+- {name: 'Darya Frank', title: 'Principal Investigator', email: 'darya.frank@manchester.ac.uk', image: 'assets/img/primary-investigator.jpg'}
 - {name: 'Marta Garcia Huescar', title: 'PhD Student', email: 'marta.garcia@ctb.upm.es', institution: 'Universidad Politecnica de Madrid', image: 'assets/img/MGH.png', text: 'Researches the functional correlates of superageing (co-supervised with Bryan Strange).'}
 - {name: 'Haoran Guan', title: 'PhD Student', email: 'haoran.guan@manchester.ac.uk', image: 'assets/img/graduate-student.jpg', text: 'Researches brain lateralisation and its affect on cognition across life span (co-supervised with Daniela Montaldi).'}
 - {name: 'Aysha Janjua', title: 'MRes Student'}

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -8,7 +8,7 @@ layout: default
 {% for person in site.data.settings.people %}
 <div class="row g-5 mb-5">
   <div class="col-md-6">
-    <h5>{{ person.title }} - {{ person.name }}</h5>
+    <h5>{{ person.name }} - {{ person.title }}</h5>
     {% if person.email %}
     <p>Email: <a href="mailto:{{ person.email }}">{{ person.email }}</a></p>
     {% endif %}

--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -8,7 +8,7 @@ layout: default
 {% for person in site.data.settings.people %}
 <div class="row g-5 mb-5">
   <div class="col-md-6">
-    <h5>{{ person.title }} - {{ person.name }}</h5>
+    <h5>{{ person.name }} - {{ person.title }}</h5>
     {% if person.email %}
     <p>Email: <a href="mailto:{{ person.email }}">{{ person.email }}</a></p>
     {% endif %}


### PR DESCRIPTION
## Summary
- display names before titles on the team page
- expand Darya Frank's title to "Principal Investigator"

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e90648e20832ea535de577ae7ba58