### PR TITLE
Fix team card layout

### DIFF
--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -8,9 +8,9 @@ layout: default
 <div class="row row-cols-1 row-cols-md-3 g-4">
   {% for person in site.data.settings.people %}
   <div class="col">
-    <div class="card h-100">
+    <div class="card h-100 team-card d-flex flex-column">
       {% if person.image %}
-      <img src="{{ site.github.url }}/{{ person.image }}" class="card-img-top" alt="{{ person.name }}">
+      <img src="{{ site.github.url }}/{{ person.image }}" class="card-img-top team-img" alt="{{ person.name }}">
       {% endif %}
       <div class="card-body">
         <h5 class="card-title">{{ person.name }} - {{ person.title }}</h5>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -116,3 +116,19 @@ hr {
     padding: 1rem;
   }
 }
+
+/* === Team Cards === */
+.team-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.team-card .card-body {
+  flex: 1 1 auto;
+}
+
+.team-img {
+  height: 250px;
+  object-fit: cover;
+  object-position: center;
+}


### PR DESCRIPTION
## Summary
- tweak team layout to allow uniform card sizes
- style team cards in custom CSS for consistent images and heights

## Testing
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685e96cde408832eb71f6be93c91ca8f