### PR TITLE
Add alumni section to team page

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -8,6 +8,8 @@ people:
 - {name: 'Darya Frank', title: 'Principal Investigator', email: 'darya.frank@manchester.ac.uk', image: 'assets/img/DRF.png'}
 - {name: 'Marta Garcia Huescar', title: 'PhD Student', email: 'marta.garcia@ctb.upm.es', institution: 'Universidad Politecnica de Madrid', image: 'assets/img/MGH.jpg', text: 'Researches the functional correlates of superageing (co-supervised with Bryan Strange).'}
 - {name: 'Haoran Guan', title: 'PhD Student', email: 'haoran.guan@manchester.ac.uk', image: 'assets/img/HG.jpeg', text: 'Researches brain lateralisation and its affect on cognition across life span (co-supervised with Daniela Montaldi).'}
+
+alumni:
 - {name: 'Aysha Janjua', title: 'MRes Student'}
 - {name: 'Zhiyun Qin', title: 'MRes Student'}
 

--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -30,3 +30,30 @@ layout: default
   </div>
   {% endfor %}
 </div>
+
+{% if site.data.settings.alumni %}
+<h3 class="fw-bold border-bottom pb-3 mb-5 mt-5">Alumni</h3>
+<div class="row row-cols-1 row-cols-md-3 g-4">
+  {% for person in site.data.settings.alumni %}
+  <div class="col">
+    <div class="card h-100 team-card d-flex flex-column">
+      {% if person.image %}
+      <img src="{{ site.github.url }}/{{ person.image }}" class="card-img-top team-img" alt="{{ person.name }}">
+      {% endif %}
+      <div class="card-body">
+        <h5 class="card-title">{{ person.name }} - {{ person.title }}</h5>
+        {% if person.email %}
+        <p class="card-text">Email: <a href="mailto:{{ person.email }}">{{ person.email }}</a></p>
+        {% endif %}
+        {% if person.institution %}
+        <p class="card-text">{{ person.institution }}</p>
+        {% endif %}
+        {% if person.text %}
+        <p class="card-text">{{ person.text }}</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}


### PR DESCRIPTION
## Summary
- add an alumni list to the settings data file and move former members there
- render an Alumni section on the team layout when alumni are defined

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69172f1ed6a4832ea43d35e92098c983)