### PR TITLE
Zoom out team page photos

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -338,8 +338,8 @@ section + section { border-top: 1px solid var(--border); }
 .team-photo img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
-  object-position: center 15%;
+  object-fit: contain;
+  object-position: center;
   display: block;
 }
 .team-photo-placeholder {


### PR DESCRIPTION
### Motivation
- Reduce cropping on team-page photos so more of each image is visible and portraits appear less zoomed-in.

### Description
- Update `assets/css/custom.css` so `.team-photo img` uses `object-fit: contain` and `object-position: center` instead of `object-fit: cover` and `object-position: center 15%` to show more image area.

### Testing
- Ran `bundle exec jekyll build`, which failed in this environment because the `jekyll` executable is not installed (Bundler suggests running `bundle install`), so no local build verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e413533ee0832ebdd29ae6b86628e2)