### PR TITLE
Add news item photos and styling

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -397,6 +397,15 @@ section + section { border-top: 1px solid var(--border); }
   margin-bottom: .5rem;
 }
 .news-body { font-size: .925rem; color: #444; line-height: 1.65; }
+.news-photo {
+  width: 100%;
+  max-width: 540px;
+  height: auto;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  margin: .5rem 0 1rem;
+  display: block;
+}
 
 /* ---------------------------------------------------------------- Contact */
 .contact-grid {

--- a/news.md
+++ b/news.md
@@ -6,12 +6,15 @@ title: "News & Updates"
 <div class="news-item">
   <div class="news-date">May 2026</div>
   <div class="news-title">Joy and Nick deliver public engagement activity</div>
+  <img class="news-photo" src="/assets/NickPE.jpg" alt="Nick Adrain at the University-Ready Open Day public engagement activity">
+  <img class="news-photo" src="/assets/JoyPE.jpg" alt="Joy Zhang at the University-Ready Open Day public engagement activity">
   <p class="news-body"> Post-doc Joy Zhang and PhD Student Nick Adrain presented their research and spoke to aspiring students at the Uniersity-Ready Open Day.</p>
 </div>
 
 <div class="news-item">
   <div class="news-date">April 2026</div>
   <div class="news-title">Nick wins an award!</div>
+  <img class="news-photo" src="/assets/NickAward.jpg" alt="Nick Adrain receiving his poster award at the Divisional Research Showcase">
   <p class="news-body"> PhD Student Nick Adrain won an award for the best poster at the Divisional Research Showcase.</p>
 </div>
 


### PR DESCRIPTION
### Motivation
- Enhance the news feed by adding illustrative photos to recent items to improve visual engagement and presentation.

### Description
- Add a new `.news-photo` CSS rule in `assets/css/custom.css` to size and style news images with max width, rounded corners, border, and spacing.
- Insert image elements into `news.md` for the May 2026 and April 2026 news entries to display `NickPE.jpg`, `JoyPE.jpg`, and `NickAward.jpg`.

### Testing
- No automated tests were run for this content/CSS update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1806266c34832e9087324b52a638fb)